### PR TITLE
OLIMS-6504: Added oauth-init endpoint for auto-approve mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Ketchup's CustomSecurityManager class includes a custom `oauth_user_info` method
 - `openlmis`
 - `OpenSRP`
 
+### Custom oAuth init endpoint
+
+One of the ideas of integration Superset with an external service (eg. OpenLMIS) is to allow run the application and sign-in directly from the external application's API. To simplify the whole process, Ketchup provides the endpoint `/oauth-init/<provider>`. Its backend functionality does the same what the endpoint `/login/<provider>` does, however it doesn't redirect a client. Instead of it, it returns information in the JSON form which contains the following fields:
+
+* `isAuthorized` - the flag which provides information about user's authorization in the app
+* `state` - oAuth state which is required during the oAuth sign-in process. It is provided only if `isAuthorized` is false
+
 #### PATCHUP_EMAIL_BASE
 
 In cases where an oAuth provider does not provide an email address for its users, Superset's oAuth process might fail.  To remedy this, Superset-patchup you can set the `PATCHUP_EMAIL_BASE` variable in `superset_config.py`.

--- a/superset_patchup/oauth.py
+++ b/superset_patchup/oauth.py
@@ -2,7 +2,8 @@
 import logging
 import re
 
-from flask import abort, flash, g, redirect, request, session, url_for, jsonify, make_response
+from flask import abort, flash, g, redirect, request, session, url_for, \
+    jsonify, make_response
 
 from flask_appbuilder._compat import as_unicode
 from flask_appbuilder.security.sqla import models as ab_models
@@ -78,23 +79,29 @@ class AuthOAuthView(SupersetAuthOAuthView):
 
     @expose("/oauth-init/<provider>")
     def login_init(self, provider=None):
-        """Checks authorization and if a user has not authenticated, inits the sign-in process and returns a state"""
-        logging.debug(f"Provider: {provider}")
+        """
+        Checks authorization and if a user is not authorized,
+        inits the sign-in process and returns a state
+        """
+        logging.debug("Provider: %s", provider)
 
         if g.user is not None and g.user.is_authenticated:
-            logging.debug(f"Provider {provider} is already authenticated by {g.user}")
+            logging.debug("Provider %s is already authorized by %s",
+                          provider, g.user)
             return make_response(jsonify(
                 isAuthorized=True
             ))
 
         redirect_url = request.args.get("redirect_url")
         if not redirect_url or not is_safe_url(redirect_url):
-            logging.debug(f"The arg redirect_url not found or not safe")
+            logging.debug("The arg redirect_url not found or not safe")
             return abort(400)
 
-        logging.debug(f"Initialization of authorization process for: {provider}")
+        logging.debug("Initialization of authorization process for: %s",
+                      provider)
 
-        # libraries assume that 'redirect_url' should be available in the session
+        # libraries assume that
+        # 'redirect_url' should be available in the session
         session['%s_oauthredir' % provider] = redirect_url
 
         state = self.generate_state()
@@ -165,12 +172,15 @@ class AuthOAuthView(SupersetAuthOAuthView):
         return redirect(self.appbuilder.get_url_for_index)
 
     def generate_state(self):
-        """Generates a state which is required during the OAuth sign-in process"""
+        """
+        Generates a state which is required during the OAuth sign-in process
+        """
         return jwt.encode(
             request.args.to_dict(flat=False),
             self.appbuilder.app.config["SECRET_KEY"],
             algorithm="HS256",
         )
+
 
 class CustomSecurityManager(SupersetSecurityManager):
     """Custom Security Manager Class"""

--- a/superset_patchup/oauth.py
+++ b/superset_patchup/oauth.py
@@ -49,7 +49,7 @@ class AuthOAuthView(SupersetAuthOAuthView):
                 appbuilder=self.appbuilder,
             )
         logging.debug(f"Going to call authorize for: {provider}")
-        state = self.generateState()
+        state = self.generate_state()
         try:
             if register:
                 logging.debug("Login to Register")
@@ -78,6 +78,7 @@ class AuthOAuthView(SupersetAuthOAuthView):
 
     @expose("/oauth-init/<provider>")
     def login_init(self, provider=None):
+        """Checks authorization and if a user has not authenticated, inits the sign-in process and returns a state"""
         logging.debug(f"Provider: {provider}")
 
         if g.user is not None and g.user.is_authenticated:
@@ -96,7 +97,7 @@ class AuthOAuthView(SupersetAuthOAuthView):
         # libraries assume that 'redirect_url' should be available in the session
         session['%s_oauthredir' % provider] = redirect_url
 
-        state = self.generateState()
+        state = self.generate_state()
         return make_response(jsonify(
             isAuthorized=False,
             state=state
@@ -163,7 +164,8 @@ class AuthOAuthView(SupersetAuthOAuthView):
 
         return redirect(self.appbuilder.get_url_for_index)
 
-    def generateState(self):
+    def generate_state(self):
+        """Generates a state which is required during the OAuth sign-in process"""
         return jwt.encode(
             request.args.to_dict(flat=False),
             self.appbuilder.app.config["SECRET_KEY"],


### PR DESCRIPTION
In order to implement [the auto-approving mechanism](https://forum.openlmis.org/t/skipping-the-oauth-approval-page/5187), we need to extend the patchup. The changes add the endpoint which simplifies OAuth sign-in process. 

Please, review and merge it. What I have noticed, you usually increment the version number and add a tag after adding new functionality. Could you do this also for these changes, so that I can point them in Superset?